### PR TITLE
Fix up the display when abrtd isn't available

### DIFF
--- a/abrt/abrt.css
+++ b/abrt/abrt.css
@@ -1,3 +1,9 @@
+.curtain-abrt {
+    height: 100%;
+    width: 100%;
+    position: fixed;
+}
+
 table
 {
     font-size: 11px;

--- a/abrt/abrt.html
+++ b/abrt/abrt.html
@@ -5,7 +5,14 @@
     <link href="abrt.css" type="text/css" rel="stylesheet">
 </head>
 <body>
-    <div class="container-fluid">
+    <div class="curtain-abrt blank-slate-pf" hidden>
+      <div class="blank-slate-pf-icon">
+        <div class="fa fa-exclamation-circle"></div>
+      </div>
+      <h1>Couldn't connect to ABRT Daemon</h1>
+      <p></p>
+    </div>
+    <div class="container-fluid page-ct" hidden>
         <div class="panel panel-default">
             <table id="problems" class="table">
                 <thead>

--- a/abrt/abrt.js
+++ b/abrt/abrt.js
@@ -44,16 +44,27 @@ $( document ).ready( function() {
     var problems = service.proxy('org.freedesktop.problems', '/org/freedesktop/problems');
 
     /* load all problems */
-    problems.wait(load_problems);
+    problems.wait().then(load_problems, display_curtains);
+
+    function display_curtains(ex) {
+	if (!ex || ex.problem == "not-found")
+	    ex = "The ABRT daemon was not found";
+        $(".curtain-abrt").show();
+        $(".container-fluid").hide();
+        $(".curtain-abrt p").text(cockpit.message(ex));
+    }
 
     function load_problems() {
         problems.GetProblems()
+	    .fail(display_curtains)
             .done(function(args, options) {
                 args.forEach(function(problem_id) {
                     problems.GetProblemData(problem_id)
                         .done(function(problem_data, options) {
                             $("#problems tbody").append(problem_data_to_row(problem_data, problem_id));
                 });
+                $(".curtain-abrt").hide();
+                $(".container-fluid").show();
             });
         });
     }


### PR DESCRIPTION
The Cockpit style is to make these messages take up the screen
and essentially disable the component